### PR TITLE
把开发依赖放到 devDependencies 里了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "request": "^2.79.0",
     "underscore": "^1.8.3"
   },
-  "optionalDependencies": {
+  "devDependencies": {
     "should": "^13.2.0",
     "mocha": "^4.0.1"
   }


### PR DESCRIPTION
为了在生产环境避免不必要的依赖安装。